### PR TITLE
Add cookie banner command example

### DIFF
--- a/cookie_banner_demo.py
+++ b/cookie_banner_demo.py
@@ -1,0 +1,44 @@
+import argparse
+from pathlib import Path
+from typing import List
+
+from openwpm.command_sequence import CommandSequence
+from openwpm.commands.browser_commands import GetCommand
+from openwpm.config import BrowserParams, ManagerParams
+from openwpm.storage.sql_provider import SQLiteStorageProvider
+from openwpm.task_manager import TaskManager
+
+from openwpm.commands.cookie_banner_commands import (
+    CookieBannerSelectionCommand,
+    LogCookieBannerOptionsCommand,
+)
+
+
+def run(site: str, options: List[str], headless: bool) -> None:
+    manager_params = ManagerParams(num_browsers=1)
+    browser_params = [BrowserParams(display_mode="headless" if headless else "native")]
+
+    manager_params.data_directory = Path("./datadir/")
+    manager_params.log_path = Path("./datadir/openwpm.log")
+
+    with TaskManager(
+        manager_params,
+        browser_params,
+        SQLiteStorageProvider(Path("./datadir/crawl-data.sqlite")),
+        None,
+    ) as manager:
+        for idx, option in enumerate(options):
+            cs = CommandSequence(site, site_rank=idx)
+            cs.append_command(GetCommand(url=site, sleep=3))
+            cs.append_command(LogCookieBannerOptionsCommand())
+            cs.append_command(CookieBannerSelectionCommand(option))
+            manager.execute_command_sequence(cs)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Crawl a site with different cookie banner selections")
+    parser.add_argument("site", help="URL of the site to crawl")
+    parser.add_argument("options", nargs="+", help="Button texts to select")
+    parser.add_argument("--headless", action="store_true", help="Run browser headless")
+    args = parser.parse_args()
+    run(args.site, args.options, args.headless)

--- a/docs/CookieBanner.md
+++ b/docs/CookieBanner.md
@@ -1,0 +1,21 @@
+# Cookie Banner Interactions
+
+This example shows how a site can be crawled multiple times while selecting different
+options on a cookie banner at the start of each visit. The commands are implemented in
+`openwpm/commands/cookie_banner_commands.py` and demonstrate how to locate banner
+buttons by their visible text.
+
+`CookieBannerSelectionCommand` clicks a button whose text matches the provided string.
+`LogCookieBannerOptionsCommand` prints all detected option texts to the log which can be
+helpful when preparing your crawl.
+
+To run the demo:
+
+```bash
+python cookie_banner_demo.py https://example.com "Alle akzeptieren" "Nur funktional" --headless
+```
+
+This will visit `https://example.com` twice, once clicking the button with the text
+`"Alle akzeptieren"` and once clicking `"Nur funktional"`. Each visit is stored in the
+result database like any other crawl allowing you to compare requests or loaded scripts
+for different consent choices.

--- a/docs/Using_OpenWPM.md
+++ b/docs/Using_OpenWPM.md
@@ -40,6 +40,8 @@ for _ in range(num_browsers):
 Please have a look at [`custom_command.py`](../custom_command.py). Note that custom commands must be
 defined in a separate module and imported. They can't be defined within the main crawl script.
 See [#837](https://github.com/openwpm/OpenWPM/issues/837).
+For an extended example that interacts with cookie consent banners see
+[`CookieBanner.md`](CookieBanner.md).
 
 ## Running a simple analysis
 

--- a/openwpm/commands/cookie_banner_commands.py
+++ b/openwpm/commands/cookie_banner_commands.py
@@ -1,0 +1,79 @@
+import logging
+from selenium.webdriver.common.by import By
+from selenium.webdriver import Firefox
+from openwpm.commands.types import BaseCommand
+from openwpm.config import BrowserParams, ManagerParams
+from openwpm.socket_interface import ClientSocket
+
+
+class CookieBannerSelectionCommand(BaseCommand):
+    """Selects a cookie banner option with the given button text."""
+
+    def __init__(self, button_text: str) -> None:
+        self.button_text = button_text
+        self.logger = logging.getLogger("openwpm")
+
+    def __repr__(self) -> str:
+        return f"CookieBannerSelectionCommand({self.button_text})"
+
+    def execute(
+        self,
+        webdriver: Firefox,
+        browser_params: BrowserParams,
+        manager_params: ManagerParams,
+        extension_socket: ClientSocket,
+    ) -> None:
+        script = """
+        const text = arguments[0].toLowerCase();
+        const banners = Array.from(document.querySelectorAll('[id*="cookie" i], [class*="cookie" i]'));
+        let buttons = [];
+        for (const banner of banners) {
+            buttons = buttons.concat(Array.from(banner.querySelectorAll('button, input[type="button"], input[type="submit"]')));
+        }
+        for (const b of buttons) {
+            const btext = (b.innerText || b.value || '').trim().toLowerCase();
+            if (btext.includes(text)) {
+                b.click();
+                return true;
+            }
+        }
+        return false;
+        """
+        try:
+            clicked = webdriver.execute_script(script, self.button_text)
+            if clicked:
+                self.logger.info("Clicked cookie banner option '%s'", self.button_text)
+            else:
+                self.logger.info("Cookie banner option '%s' not found", self.button_text)
+        except Exception as exc:
+            self.logger.error("Cookie banner selection failed: %s", exc)
+
+
+class LogCookieBannerOptionsCommand(BaseCommand):
+    """Logs available cookie banner option texts"""
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger("openwpm")
+
+    def __repr__(self) -> str:
+        return "LogCookieBannerOptionsCommand"
+
+    def execute(
+        self,
+        webdriver: Firefox,
+        browser_params: BrowserParams,
+        manager_params: ManagerParams,
+        extension_socket: ClientSocket,
+    ) -> None:
+        script = """
+        const banner = document.querySelector('[id*="cookie" i], [class*="cookie" i]');
+        if (!banner) { return []; }
+        const btns = banner.querySelectorAll('button, input[type="button"], input[type="submit"]');
+        return Array.from(btns).map(b => (b.innerText || b.value || '').trim()).filter(t => t);
+        """
+        try:
+            options = webdriver.execute_script(script)
+            self.logger.info("Cookie banner options: %s", options)
+        except Exception as exc:
+            self.logger.error("Failed to extract cookie banner options: %s", exc)
+


### PR DESCRIPTION
## Summary
- create `CookieBannerSelectionCommand` and `LogCookieBannerOptionsCommand`
- demo running multiple crawls with different cookie consent selections
- document cookie banner example and link it from Using_OpenWPM

## Testing
- `py.test -vv` *(fails: ModuleNotFoundError: No module named 'dataclasses_json')*

------
https://chatgpt.com/codex/tasks/task_e_6845b85bb5648320909678ffadecbccd