### PR TITLE
Ensure cookie banner demo resets browser

### DIFF
--- a/cookie_banner_demo.py
+++ b/cookie_banner_demo.py
@@ -4,14 +4,13 @@ from typing import List
 
 from openwpm.command_sequence import CommandSequence
 from openwpm.commands.browser_commands import GetCommand
-from openwpm.config import BrowserParams, ManagerParams
-from openwpm.storage.sql_provider import SQLiteStorageProvider
-from openwpm.task_manager import TaskManager
-
 from openwpm.commands.cookie_banner_commands import (
     CookieBannerSelectionCommand,
     LogCookieBannerOptionsCommand,
 )
+from openwpm.config import BrowserParams, ManagerParams
+from openwpm.storage.sql_provider import SQLiteStorageProvider
+from openwpm.task_manager import TaskManager
 
 
 def run(site: str, options: List[str], headless: bool) -> None:
@@ -28,7 +27,7 @@ def run(site: str, options: List[str], headless: bool) -> None:
         None,
     ) as manager:
         for idx, option in enumerate(options):
-            cs = CommandSequence(site, site_rank=idx)
+            cs = CommandSequence(site, site_rank=idx, reset=True)
             cs.append_command(GetCommand(url=site, sleep=3))
             cs.append_command(LogCookieBannerOptionsCommand())
             cs.append_command(CookieBannerSelectionCommand(option))
@@ -36,7 +35,9 @@ def run(site: str, options: List[str], headless: bool) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Crawl a site with different cookie banner selections")
+    parser = argparse.ArgumentParser(
+        description="Crawl a site with different cookie banner selections"
+    )
     parser.add_argument("site", help="URL of the site to crawl")
     parser.add_argument("options", nargs="+", help="Button texts to select")
     parser.add_argument("--headless", action="store_true", help="Run browser headless")

--- a/docs/CookieBanner.md
+++ b/docs/CookieBanner.md
@@ -19,3 +19,6 @@ This will visit `https://example.com` twice, once clicking the button with the t
 `"Alle akzeptieren"` and once clicking `"Nur funktional"`. Each visit is stored in the
 result database like any other crawl allowing you to compare requests or loaded scripts
 for different consent choices.
+
+Each option is crawled in a fresh browser profile. This is achieved by creating the
+`CommandSequence` with `reset=True`, causing the browser to restart before every visit.


### PR DESCRIPTION
## Summary
- restart the browser between cookie banner options
- document the need for `reset=True`

## Testing
- `isort --profile black --check cookie_banner_demo.py docs/CookieBanner.md`
- `black --check cookie_banner_demo.py`
- `mypy cookie_banner_demo.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dataclasses_json')*
- `pre-commit run --files cookie_banner_demo.py docs/CookieBanner.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889fbf64c548320a8fde863169febb6