### PR TITLE
Add cookie banner toggle command

### DIFF
--- a/cookie_banner_demo.py
+++ b/cookie_banner_demo.py
@@ -6,6 +6,7 @@ from openwpm.command_sequence import CommandSequence
 from openwpm.commands.browser_commands import GetCommand
 from openwpm.commands.cookie_banner_commands import (
     CookieBannerSelectionCommand,
+    CookieBannerToggleCommand,
     LogCookieBannerOptionsCommand,
 )
 from openwpm.config import BrowserParams, ManagerParams
@@ -13,7 +14,7 @@ from openwpm.storage.sql_provider import SQLiteStorageProvider
 from openwpm.task_manager import TaskManager
 
 
-def run(site: str, options: List[str], headless: bool) -> None:
+def run(site: str, options: List[str], toggles: List[str], headless: bool) -> None:
     manager_params = ManagerParams(num_browsers=1)
     browser_params = [BrowserParams(display_mode="headless" if headless else "native")]
 
@@ -30,6 +31,8 @@ def run(site: str, options: List[str], headless: bool) -> None:
             cs = CommandSequence(site, site_rank=idx, reset=True)
             cs.append_command(GetCommand(url=site, sleep=3))
             cs.append_command(LogCookieBannerOptionsCommand())
+            for toggle in toggles:
+                cs.append_command(CookieBannerToggleCommand(toggle))
             cs.append_command(CookieBannerSelectionCommand(option))
             manager.execute_command_sequence(cs)
 
@@ -40,6 +43,13 @@ if __name__ == "__main__":
     )
     parser.add_argument("site", help="URL of the site to crawl")
     parser.add_argument("options", nargs="+", help="Button texts to select")
+    parser.add_argument(
+        "--toggle",
+        dest="toggles",
+        action="append",
+        default=[],
+        help="Label texts of checkboxes or switches to toggle before consenting",
+    )
     parser.add_argument("--headless", action="store_true", help="Run browser headless")
     args = parser.parse_args()
-    run(args.site, args.options, args.headless)
+    run(args.site, args.options, args.toggles, args.headless)

--- a/docs/CookieBanner.md
+++ b/docs/CookieBanner.md
@@ -6,13 +6,14 @@ options on a cookie banner at the start of each visit. The commands are implemen
 buttons by their visible text.
 
 `CookieBannerSelectionCommand` clicks a button whose text matches the provided string.
+`CookieBannerToggleCommand` clicks a checkbox or switch matching its label text.
 `LogCookieBannerOptionsCommand` prints all detected option texts to the log which can be
 helpful when preparing your crawl.
 
 To run the demo:
 
 ```bash
-python cookie_banner_demo.py https://example.com "Alle akzeptieren" "Nur funktional" --headless
+python cookie_banner_demo.py https://example.com "Alle akzeptieren" "Nur funktional" --toggle "Werbung" --toggle "Analyse" --headless
 ```
 
 This will visit `https://example.com` twice, once clicking the button with the text

--- a/openwpm/commands/cookie_banner_commands.py
+++ b/openwpm/commands/cookie_banner_commands.py
@@ -77,3 +77,55 @@ class LogCookieBannerOptionsCommand(BaseCommand):
         except Exception as exc:
             self.logger.error("Failed to extract cookie banner options: %s", exc)
 
+
+class CookieBannerToggleCommand(BaseCommand):
+    """Toggles a checkbox or switch matching the given label text."""
+
+    def __init__(self, label_text: str) -> None:
+        self.label_text = label_text
+        self.logger = logging.getLogger("openwpm")
+
+    def __repr__(self) -> str:
+        return f"CookieBannerToggleCommand({self.label_text})"
+
+    def execute(
+        self,
+        webdriver: Firefox,
+        browser_params: BrowserParams,
+        manager_params: ManagerParams,
+        extension_socket: ClientSocket,
+    ) -> None:
+        script = """
+        const text = arguments[0].toLowerCase();
+        const banners = Array.from(document.querySelectorAll('[id*="cookie" i], [class*="cookie" i]'));
+        let toggles = [];
+        for (const banner of banners) {
+            toggles = toggles.concat(Array.from(banner.querySelectorAll('input[type="checkbox"], input[type="radio"], [role="switch"]')));
+        }
+        for (const t of toggles) {
+            let label = '';
+            if (t.labels && t.labels.length) {
+                label = Array.from(t.labels).map(l => (l.innerText || '').trim()).join(' ').toLowerCase();
+            }
+            if (!label && t.getAttribute('aria-label')) {
+                label = t.getAttribute('aria-label').trim().toLowerCase();
+            }
+            if (!label && t.parentElement) {
+                label = (t.parentElement.innerText || '').trim().toLowerCase();
+            }
+            if (label.includes(text)) {
+                t.click();
+                return true;
+            }
+        }
+        return false;
+        """
+        try:
+            clicked = webdriver.execute_script(script, self.label_text)
+            if clicked:
+                self.logger.info("Toggled cookie banner option '%s'", self.label_text)
+            else:
+                self.logger.info("Cookie banner toggle '%s' not found", self.label_text)
+        except Exception as exc:
+            self.logger.error("Cookie banner toggle failed: %s", exc)
+


### PR DESCRIPTION
## Summary
- implement `CookieBannerToggleCommand` to toggle checkboxes or switches by matching label text
- extend `cookie_banner_demo.py` with new command and CLI option for toggles
- document toggle command usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dataclasses_json')*

------
https://chatgpt.com/codex/tasks/task_e_688a023a4f888320bf699e38b651c25c