### PR TITLE
Add macOS spawn start method

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ available.
     in bash). Please also add a comment to that issue to let us know you ran
     into this problem.
 
+7. On macOS you might see a crash mentioning `objc` and `initialize` when the
+    browser restarts. This happens because the default `fork` start method of
+    Python's multiprocessing does not work well with GUI frameworks on macOS.
+    Before running the demo, set the start method to `spawn` or run the demo via
+    Docker:
+
+    ```python
+    import multiprocessing
+    multiprocessing.set_start_method("spawn")
+    ```
+
+    See [docs/Troubleshooting.md](docs/Troubleshooting.md) for details.
+
 ## Documentation
 
 Further information is available at [OPENWPM's Documentation Page](https://openwpm.readthedocs.io).

--- a/cookie_banner_demo.py
+++ b/cookie_banner_demo.py
@@ -1,6 +1,8 @@
 import argparse
 from pathlib import Path
 from typing import List
+import multiprocessing
+import sys
 
 from openwpm.command_sequence import CommandSequence
 from openwpm.commands.browser_commands import GetCommand
@@ -11,6 +13,9 @@ from openwpm.commands.cookie_banner_commands import (
 from openwpm.config import BrowserParams, ManagerParams
 from openwpm.storage.sql_provider import SQLiteStorageProvider
 from openwpm.task_manager import TaskManager
+
+if sys.platform == "darwin":
+    multiprocessing.set_start_method("spawn", force=True)
 
 
 def run(site: str, options: List[str], headless: bool) -> None:

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,8 @@
 import argparse
 from pathlib import Path
 from typing import Literal
+import multiprocessing
+import sys
 
 import tranco
 
@@ -10,6 +12,9 @@ from openwpm.commands.browser_commands import GetCommand
 from openwpm.config import BrowserParams, ManagerParams
 from openwpm.storage.sql_provider import SQLiteStorageProvider
 from openwpm.task_manager import TaskManager
+
+if sys.platform == "darwin":
+    multiprocessing.set_start_method("spawn", force=True)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--tranco", action="store_true", default=False)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,0 +1,23 @@
+# Troubleshooting
+
+## Crash on macOS when restarting the browser
+
+On some macOS systems the demo may crash with an error similar to:
+
+```
+objc[...]: +[__NSPlaceholderDictionary initialize] may have been inserted by the dynamic linker...
+```
+
+This occurs when the browser process is restarted using Python's default `fork` start method for multiprocessing. macOS does not fully support forking processes that use the system GUI frameworks. You can avoid the crash in two ways:
+
+1. Explicitly set the multiprocessing start method to `spawn`:
+
+   ```python
+   import multiprocessing
+   multiprocessing.set_start_method("spawn")
+   ```
+
+   Add this before running `demo.py` or your own script.
+
+2. Alternatively, run OpenWPM inside Docker using the provided Dockerfile or helper scripts. Docker uses a Linux environment where this issue does not occur.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,8 @@ We're hoping to improve this setup in the future.
 
    Configuration
 
+   Troubleshooting
+
    Papers
 
 .. toctree::


### PR DESCRIPTION
## Summary
- document workaround for `objc ... initialize` crash on macOS
- reference troubleshooting docs from README with a hyperlink
- include new document in sphinx TOC
- set the spawn start method in demo script when running on macOS
- also apply spawn start method in cookie banner demo

## Testing
- `python -m pytest -k "nothing" -s` *(fails: ModuleNotFoundError: No module named 'dataclasses_json')*


------
https://chatgpt.com/codex/tasks/task_e_688a023cb2d08320b9bfa0d074c83a01